### PR TITLE
Configure less driving for P&R results

### DIFF
--- a/puget-sound/community-transit/production/router-config.json
+++ b/puget-sound/community-transit/production/router-config.json
@@ -9,7 +9,8 @@
     "transferSlack": "300s",
     "boardSlack": "300s",
     "car": {
-      "speed": 25
+      "speed": 25,
+      "reluctance": 5
     },
     "wheelchairAccessibility": {
       "trip": {
@@ -32,6 +33,11 @@
       "parkAndRideDurationRatio": 0.9,
       "bikeRentalDistanceRatio": 0.9,
       "nonTransitGeneralizedCostLimit": "0 + 1.5 x"
+    },
+    "accessEgress": {
+      "penalty": {
+        "car-to-park" : { "timePenalty": "5m + 5t", "costFactor": 5 }
+      }
     }
   },
   "vectorTiles": {

--- a/puget-sound/community-transit/test/router-config.json
+++ b/puget-sound/community-transit/test/router-config.json
@@ -22,9 +22,9 @@
     },
     "transferSlack": "300s",
     "boardSlack": "300s",
-    "car": { 
+    "car": {
       "speed": 25,
-      "reluctance" 5
+      "reluctance": 5
     },
     "wheelchairAccessibility": {
       "trip": {

--- a/puget-sound/community-transit/test/router-config.json
+++ b/puget-sound/community-transit/test/router-config.json
@@ -13,7 +13,7 @@
   "routingDefaults": {
     "accessEgress": {
       "penalty": {
-        "car-to-park" : { "timePenalty": "10m + 1.5t", "costFactor": 2.5 },
+        "car-to-park" : { "timePenalty": "5m + 5t", "costFactor": 5 },
         "FLEXIBLE" : {
           "timePenalty" : "10m + 1.3t",
           "costFactor" : 1.2
@@ -22,7 +22,10 @@
     },
     "transferSlack": "300s",
     "boardSlack": "300s",
-    "car": { "speed": 25 },
+    "car": { 
+      "speed": 25,
+      "reluctance" 5
+    },
     "wheelchairAccessibility": {
       "trip": {
         "onlyConsiderAccessible": false,


### PR DESCRIPTION
As requested by @whitneys-pm this reduces the driving for the P&R results for Community Transit.