### PR TITLE
Activate area visibility for CT

### DIFF
--- a/puget-sound/community-transit/production/build-config.json
+++ b/puget-sound/community-transit/production/build-config.json
@@ -1,4 +1,5 @@
 {
+  "areaVisibility": true,
   "transitModelTimeZone": "America/Los_Angeles",
   "fares": "orca",
   "islandPruning": {

--- a/puget-sound/community-transit/test/build-config.json
+++ b/puget-sound/community-transit/test/build-config.json
@@ -1,4 +1,5 @@
 {
+  "areaVisibility": true,
   "transitModelTimeZone": "America/Los_Angeles",
   "fares": "orca",
   "islandPruning": {


### PR DESCRIPTION
This is needed so you can leave Capitol Hill on a bike.