### PR TITLE
Make Seattle island pruning a lot less aggressive

### DIFF
--- a/puget-sound/community-transit/production/build-config.json
+++ b/puget-sound/community-transit/production/build-config.json
@@ -4,7 +4,7 @@
   "fares": "orca",
   "islandPruning": {
     "islandWithoutStopsMaxSize": 300,
-    "islandWithStopsMaxSize": 300
+    "islandWithStopsMaxSize": 30 // Seattle has many actual islands, so don't make this too aggressive
   },
   "boardingLocationTags": [],
   "transferRequests": [

--- a/puget-sound/community-transit/test/build-config.json
+++ b/puget-sound/community-transit/test/build-config.json
@@ -4,7 +4,7 @@
   "fares": "orca",
   "islandPruning": {
     "islandWithoutStopsMaxSize": 300,
-    "islandWithStopsMaxSize": 300
+    "islandWithStopsMaxSize": 30 // Seattle has many actual islands, so don't make this too aggressive
   },
   "boardingLocationTags": [],
   "transferRequests": [

--- a/puget-sound/sound-transit/production/build-config.json
+++ b/puget-sound/sound-transit/production/build-config.json
@@ -3,7 +3,7 @@
   "fares": "orca",
   "islandPruning": {
     "islandWithoutStopsMaxSize": 300,
-    "islandWithStopsMaxSize": 300
+    "islandWithStopsMaxSize": 30 // Seattle has many actual islands, so don't make this too aggressive
   },
   "stopConsolidationFile": "shared_stops.csv",
   "boardingLocationTags": [],

--- a/puget-sound/sound-transit/qa/build-config.json
+++ b/puget-sound/sound-transit/qa/build-config.json
@@ -5,7 +5,7 @@
   "boardingLocationTags": [],
   "islandPruning": {
     "islandWithoutStopsMaxSize": 300,
-    "islandWithStopsMaxSize": 300
+    "islandWithStopsMaxSize": 30 // Seattle has many actual islands, so don't make this too aggressive
   },
   "transferRequests": [
     {


### PR DESCRIPTION
The current setting leads to Vashon Island being pruned away!

![image](https://github.com/user-attachments/assets/221c9c3b-3ea9-4c63-877b-e5dd65a8f81d)
