### PR TITLE
ATL: Enable sidewalk naming

### DIFF
--- a/atlanta/atl/production/build-config.json
+++ b/atlanta/atl/production/build-config.json
@@ -2,6 +2,7 @@
   "osmDefaults": {
     "osmTagMapping": "atlanta"
   },
+  "osmNaming": "sidewalks",
   "fares": "off",
   "transitModelTimeZone": "America/New_York",
   "areaVisibility": true,


### PR DESCRIPTION
This PR enables sidewalk naming for ATL RIDES.