### PR TITLE
Update lime gbfs to v2

### DIFF
--- a/puget-sound/sound-transit/qa/router-config.json
+++ b/puget-sound/sound-transit/qa/router-config.json
@@ -92,12 +92,6 @@
       "url": "https://data.lime.bike/api/partners/v1/gbfs/seattle/gbfs.json"
     },
     {
-      "type": "vehicle-rental",
-      "frequency": "20s",
-      "sourceType": "gbfs",
-      "url": "https://mds.linkyour.city/gbfs/us_wa_seattle/gbfs.json"
-    },
-    {
       "type": "real-time-alerts",
       "frequency": "20s",
       "url": "http://s3.amazonaws.com/commtrans-realtime-prod/alerts.pb",

--- a/puget-sound/sound-transit/qa/router-config.json
+++ b/puget-sound/sound-transit/qa/router-config.json
@@ -89,7 +89,7 @@
       "type": "vehicle-rental",
       "frequency": "20s",
       "sourceType": "gbfs",
-      "url": "https://data.lime.bike/api/partners/v1/gbfs/seattle/gbfs.json"
+      "url": "https://data.lime.bike/api/partners/v2/gbfs/seattle/gbfs.json"
     },
     {
       "type": "real-time-alerts",


### PR DESCRIPTION
This update allows us to distinguish between Lime scooters and Lime bikes. Previously, we were showing all vehicles as bikes because that is the default and the v1 GBFS feed doesn't support vehicle types.

<img width="590" height="364" alt="image" src="https://github.com/user-attachments/assets/791f31a0-5fde-4bc7-bed9-fdb5852cbf7d" />
