### PR TITLE
Configure new `fares` default

### DIFF
--- a/denver/rtd/build-config.json
+++ b/denver/rtd/build-config.json
@@ -1,4 +1,5 @@
 {
   "maxTransferDuration": "1h",
-  "transitModelTimeZone": "America/Denver"
+  "transitModelTimeZone": "America/Denver",
+  "fares": "gtfs"
 }

--- a/septa/build-config.json
+++ b/septa/build-config.json
@@ -13,5 +13,6 @@
   "gtfsDefaults" : {
     "blockBasedInterlining" : true
   },
-  "subwayAccessTime": 0
+  "subwayAccessTime": 0,
+  "fares": "gtfs"
 }

--- a/twin-cities/production/build-config.json
+++ b/twin-cities/production/build-config.json
@@ -17,5 +17,6 @@
         "enabled": true
       }
     }
-  ]
+  ],
+  "fares": "gtfs"
 }


### PR DESCRIPTION
After https://github.com/ibi-group/OpenTripPlanner/pull/299 is merged, there will be a new default value for the fares config, which this sets.